### PR TITLE
Added score_only option.

### DIFF
--- a/src/metal_dock/docking.py
+++ b/src/metal_dock/docking.py
@@ -65,7 +65,6 @@ class Docking:
         self._run_autogrid(autogrid_logfile, gpf_path)
         self._run_autodock(autodock_logfile, dpf_path)
         if not self.par.score_only:
-            print(self.par.score_only)
             self._write_conformations(dlg_path, dock_dir_path)
             # self._adding_and_optimizing_hydrogens()
             self._clean_dummy_atoms()

--- a/src/metal_dock/main.py
+++ b/src/metal_dock/main.py
@@ -19,6 +19,7 @@ def docking(par: DockParser):
         par (DockParser): The parser object.
     """
     input_dir = Path.cwd()
+    par.input_dir = input_dir
     par.output_dir = input_dir / 'output'
     #=== OUTPUT DIRECTORY ===#
     par.output_dir.mkdir(exist_ok=True)

--- a/src/metal_dock/metal_complex.py
+++ b/src/metal_dock/metal_complex.py
@@ -38,7 +38,10 @@ class MetalComplex:
             run_type (str): The type of run.
         """
         mg = MolGraph()
-        mg.read_xyz(self.par.output_dir / 'QM' / run_type / 'output.xyz')
+        if self.par.score_only:
+            mg.read_xyz(self.par.input_dir / f'{self.par.name_ligand}.xyz')
+        else:
+            mg.read_xyz(self.par.output_dir / 'QM' / run_type / 'output.xyz')
         self.graph = to_networkx_graph(mg)
 
     def add_charges_to_graph(self):

--- a/src/metal_dock/parser_metal_dock.py
+++ b/src/metal_dock/parser_metal_dock.py
@@ -55,7 +55,8 @@ STANDARD_DEFAULTS = {
     'temp_reduction_factor': 0.90,
     'number_of_runs': 50,
     'max_cycles': 50,
-    'mc_steps': 250
+    'mc_steps': 250,
+    'score_only': False
 }
 
              #         e_NA, e_OA, e_SA,  e_HD,
@@ -154,8 +155,8 @@ class ParserBase:
         if self.sa_dock:
             self.dock_algorithm = [self.temp_reduction_factor, self.number_of_runs, self.max_cycles]
 
-        if not self.ga_dock and not self.sa_dock:
-            self.logger.info('At least ga_dock or sa_dock must be set to True for MetalDock to run properly')
+        if not self.ga_dock and not self.sa_dock and not self.score_only:
+            self.logger.info('At least ga_dock or sa_dock or score_only must be set to True for MetalDock to run properly')
             sys.exit()
 
 
@@ -284,6 +285,8 @@ class DockParser(ParserBase):
         self.temp_reduction_factor = self.get_config_value('DOCKING', 'temp_reduction_factor', STANDARD_DEFAULTS['temp_reduction_factor'], float)
         self.number_of_runs = self.get_config_value('DOCKING', 'number_of_runs', STANDARD_DEFAULTS['number_of_runs'], int)
         self.max_cycles = self.get_config_value('DOCKING', 'max_cycles', STANDARD_DEFAULTS['max_cycles'], int)
+
+        self.score_only = self.get_config_value('DOCKING', 'score_only', STANDARD_DEFAULTS['score_only'], bool)
 
         self._validate_docking_algorithm()
 

--- a/src/metal_dock/parser_metal_dock.py
+++ b/src/metal_dock/parser_metal_dock.py
@@ -155,6 +155,10 @@ class ParserBase:
         if self.sa_dock:
             self.dock_algorithm = [self.temp_reduction_factor, self.number_of_runs, self.max_cycles]
 
+        if self.score_only and (self.ga_dock or self.sa_dock):
+            self.logger.info('ga_dock and/or sa_dock must be set to False when performing score_only')
+            sys.exit()
+
         if not self.ga_dock and not self.sa_dock and not self.score_only:
             self.logger.info('At least ga_dock or sa_dock or score_only must be set to True for MetalDock to run properly')
             sys.exit()


### PR DESCRIPTION
### Summary
This adds a `score_only` function to MetalDock that evaluates docking scores of input pose without performing any local or global searches. The workflow remains the same.
### Why
Useful when working with different conformations of same ligand and receptor (for example, conformations sampled using MD simulations).
### Requirements
As usually, requires a `ligand.xyz`, a `receptor.pdb` and an input file. Inside input file, in `[DOCKING]` section, `score_only = True` must be set.
### Limitations
Single-point calculations are still required to derive the partial charges of the atoms, which is relatively slow. However, there is a workaround: perform the single-point calculation once and then reuse the QM output in subsequent calculations for the same ligand (but with a different conformation).
### Misc
This is my first PR ever. Feel free to give any opinion.